### PR TITLE
ci: fix jacoco reporting for sonarqube

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,8 @@ jacocoTestReport {
     }
 }
 
+test.finalizedBy jacocoTestReport
+
 test {
     useJUnitPlatform()
     reports.junitXml.enabled = true

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="1.0" author="andreas">
+        <sqlFile dbms="h2" path="db/changelog-h2-1.0.sql" />
+        <sqlFile dbms="postgresql" path="db/changelog-postgresql-1.0.sql" />
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
One line from build.gradle was accidentally removed breaking the code coverage reporting